### PR TITLE
Add 'TestMode' argument to 'parseModelScript'

### DIFF
--- a/sources/framework/visioneval/R/initialization.R
+++ b/sources/framework/visioneval/R/initialization.R
@@ -656,124 +656,134 @@ loadModelParameters <- function(ModelParamFile = "model_parameters.json") {
 #' order of the calls. Each row represents a module call in order. The columns
 #' identify the 'ModuleName', the 'PackageName', and the 'RunFor' value.
 #' @export
-parseModelScript <- function(FilePath = "run_model.R") {
-  writeLog("Parsing model script")
-  Script <- paste(readLines(FilePath), collapse = " ")
-  RunModuleCalls_ <- unlist(strsplit(Script, "runModule"))[-1]
-  Errors_ <- character(0)
-  addError <- function(Error) {
-    Errors_ <<- c(Errors_, Error)
-  }
-  #Utility function to remove spaces from string
-  removeSpaces <- function(String) {
-    gsub(" ", "", String)
-  }
-  #Utility function to clean up string
-  cleanString <- function(String) {
-    ToRemove = c(" ", "\\(", ")", '\\\"')
-    for (SubString in ToRemove) {
-      String <- gsub(SubString, "", String)
+parseModelScript <-
+  function(FilePath = "run_model.R",
+           TestMode = FALSE) {
+    if (!TestMode) {
+      writeLog("Parsing model script")
     }
-    String
-  }
-  #Utility function to extract the arguments part of a function call
-  extractArgsString <- function(String) {
-    substring(String,
-              regexpr("\\(", String),
-              regexpr("\\)", String))
-  }
-  #Utility function to extract the value of a named argument
-  getNamedArgumentValue <-
-    function(ArgString, ArgName) {
-      CommaPos <- regexpr(",", ArgString)
-      if (CommaPos > 0) {
-        ArgValue <-
+    Script <- paste(readLines(FilePath), collapse = " ")
+    RunModuleCalls_ <- unlist(strsplit(Script, "runModule"))[-1]
+    Errors_ <- character(0)
+    addError <- function(Error) {
+      Errors_ <<- c(Errors_, Error)
+    }
+    #Utility function to remove spaces from string
+    removeSpaces <- function(String) {
+      gsub(" ", "", String)
+    }
+    #Utility function to clean up string
+    cleanString <- function(String) {
+      ToRemove = c(" ", "\\(", ")", '\\\"')
+      for (SubString in ToRemove) {
+        String <- gsub(SubString, "", String)
+      }
+      String
+    }
+    #Utility function to extract the arguments part of a function call
+    extractArgsString <- function(String) {
+      substring(String,
+                regexpr("\\(", String),
+                regexpr("\\)", String))
+    }
+    #Utility function to extract the value of a named argument
+    getNamedArgumentValue <-
+      function(ArgString, ArgName) {
+        CommaPos <- regexpr(",", ArgString)
+        if (CommaPos > 0) {
+          ArgValue <-
+            substring(ArgString,
+                      regexpr("=", ArgString) + 1,
+                      CommaPos - 1)
+        } else {
+          ArgValue <-
+            substring(ArgString,
+                      regexpr("=", ArgString) + 1,
+                      nchar(ArgString))
+        }
+        cleanString(ArgValue)
+      }
+    #Utility function to extract the value of an unnamed argument
+    getUnnamedArgumentValue <-
+      function(ArgString) {
+        ArgStringTrim <-
           substring(ArgString,
-                    regexpr("=", ArgString) + 1,
-                    CommaPos - 1)
-      } else {
-        ArgValue <-
-          substring(ArgString,
-                    regexpr("=", ArgString) + 1,
+                    regexpr("\\\"", ArgString) + 1,
                     nchar(ArgString))
+        cleanString(substring(ArgStringTrim,
+                              1,
+                              regexpr("\\\"", ArgStringTrim)))
       }
-      cleanString(ArgValue)
+    #Function to extract the name and value of an argument from a string
+    getArg <-
+      function(ArgsString, ArgPos) {
+        ArgString <- removeSpaces(ArgsString[ArgPos])
+        #Define standard argument names
+        ArgNames_ <-
+          c("ModuleName", "PackageName", "RunFor", "Year")
+        #Check whether any of the argument names is in the ArgString
+        ArgNameCheck_ <-
+          sapply(ArgNames_, function(x) {
+            ArgName <- paste0(x, "=")
+            regexpr(ArgName, ArgString)
+          }) > 0
+        if (any(ArgNameCheck_)) {
+          ArgName <- names(ArgNameCheck_)[ArgNameCheck_]
+          ArgValue <- getNamedArgumentValue(ArgString, ArgName)
+        } else {
+          ArgName <- ArgNames_[ArgPos]
+          ArgValue <- getUnnamedArgumentValue(ArgString)
+        }
+        list(ArgName = ArgName, ArgValue = ArgValue)
+      }
+    #Function to extract all the arguments of runModule function call
+    getArgs <-
+      function(String) {
+        PrelimArgs_ <- unlist(strsplit(extractArgsString(String), ","))
+        Args_ls <-
+          list(ModuleName = NULL,
+               PackageName = NULL,
+               RunFor = NULL)
+        for (i in 1:length(PrelimArgs_)) {
+          Arg_ls <- getArg(PrelimArgs_, i)
+          Args_ls[[Arg_ls$ArgName]] <- Arg_ls$ArgValue
+        }
+        unlist(Args_ls)
+      }
+    #Iterate through RunModuleCalls_ and extract the arguments
+    Args_ls <- list()
+    for (i in 1:length(RunModuleCalls_)) {
+      Args_ <- getArgs(RunModuleCalls_[i])
+      #Error if not all mandatory arguments are matched
+      if (length(Args_) != 3) {
+        Msg <- paste0("runModule call #",
+                      i,
+                      " has improperly specified arguments.")
+        addError(Msg)
+      }
+      #Add to list
+      Args_ls[[i]] <- Args_
     }
-  #Utility function to extract the value of an unnamed argument
-  getUnnamedArgumentValue <-
-    function(ArgString) {
-      ArgStringTrim <-
-        substring(ArgString,
-                  regexpr("\\\"", ArgString) + 1,
-                  nchar(ArgString))
-      cleanString(
-        substring(ArgStringTrim,
-                  1,
-                  regexpr("\\\"", ArgStringTrim))
+    #If there are any errors, print error message
+    if (length(Errors_) != 0) {
+      if (!TestMode) {
+        writeLog("One or more 'runModule' function calls have errors as follows:")
+        writeLog(Errors_)
+      }
+      stop(
+        "One or more errors in model run script. Must fix before model initialization can be completed."
       )
-    }
-  #Function to extract the name and value of an argument from a string
-  getArg <-
-    function(ArgsString, ArgPos) {
-      ArgString <- removeSpaces(ArgsString[ArgPos])
-      #Define standard argument names
-      ArgNames_ <-
-        c("ModuleName", "PackageName", "RunFor", "Year")
-      #Check whether any of the argument names is in the ArgString
-      ArgNameCheck_ <-
-        sapply(ArgNames_, function(x) {
-          ArgName <- paste0(x, "=")
-          regexpr(ArgName, ArgString)
-        }) > 0
-      if (any(ArgNameCheck_)) {
-        ArgName <- names(ArgNameCheck_)[ArgNameCheck_]
-        ArgValue <- getNamedArgumentValue(ArgString, ArgName)
+    } else {
+      ModuleCalls_df <-
+        data.frame(do.call(rbind, Args_ls), stringsAsFactors = FALSE)
+      if (TestMode) {
+        ModuleCalls_df
       } else {
-        ArgName <- ArgNames_[ArgPos]
-        ArgValue <- getUnnamedArgumentValue(ArgString)
+        writeLog("Success parsing model script")
+        setModelState(list(ModuleCalls_df = ModuleCalls_df))
       }
-      list(ArgName = ArgName, ArgValue = ArgValue)
     }
-  #Function to extract all the arguments of runModule function call
-  getArgs <-
-    function(String){
-      PrelimArgs_ <- unlist(strsplit(extractArgsString(String), ","))
-      Args_ls <-
-        list(ModuleName = NULL,
-             PackageName = NULL,
-             RunFor = NULL)
-      for (i in 1:length(PrelimArgs_)) {
-        Arg_ls <- getArg(PrelimArgs_, i)
-        Args_ls[[Arg_ls$ArgName]] <- Arg_ls$ArgValue
-      }
-      unlist(Args_ls)
-    }
-  #Iterate through RunModuleCalls_ and extract the arguments
-  Args_ls <- list()
-  for (i in 1:length(RunModuleCalls_)) {
-    Args_ <- getArgs(RunModuleCalls_[i])
-    #Error if not all mandatory arguments are matched
-    if (length(Args_) != 3) {
-      Msg <- paste0(
-        "runModule call #", i, " has improperly specified arguments."
-      )
-      addError(Msg)
-    }
-    #Add to list
-    Args_ls[[i]] <- Args_
   }
-  #If there are any errors, print error message
-  if (length(Errors_) != 0) {
-    writeLog("One or more 'runModule' function calls have errors as follows:")
-    writeLog(Errors_)
-    stop("One or more errors in model run script. Must fix before model initialization can be completed.")
-  } else {
-    writeLog("Success parsing model script")
-    ModuleCalls_df <-
-      data.frame(do.call(rbind, Args_ls), stringsAsFactors = FALSE)
-    setModelState(list(ModuleCalls_df = ModuleCalls_df))
-  }
-}
 
 
 #CHECK MODULE AVAILABILITY


### PR DESCRIPTION
Added 'TestMode' argument to 'parseModelScript' function. If TestMode is FALSE (default) the function runs normally (changes model state list and writes to log). If TRUE, it parses the model script and returns the result.