### PR TITLE
AltModeModels_ls.RData > AltModeModels_ls.rda

### DIFF
--- a/sources/modules/VEHouseholdTravel/R/CalculateAltModeTrips.R
+++ b/sources/modules/VEHouseholdTravel/R/CalculateAltModeTrips.R
@@ -15,7 +15,7 @@
 #SECTION 1: ESTIMATE AND SAVE MODEL PARAMETERS
 #=============================================
 #Load the alternative mode trip models from GreenSTEP
-load("inst/extdata/AltModeModels_ls.RData")
+load("inst/extdata/AltModeModels_ls.rda")
 #Save the model
 #' Alternative mode trip models
 #'


### PR DESCRIPTION
Loading VEHouseholdTravel was failing 
```
In readChar(con, 5L, useBytes = TRUE) :
  cannot open compressed file 'inst/extdata/AltModeModels_ls.RData', probable reason 'No such file or directory'
```