### PR TITLE
Allow model and inputs+defs to reside in different directories.

### DIFF
--- a/sources/framework/visioneval/R/initialization.R
+++ b/sources/framework/visioneval/R/initialization.R
@@ -770,7 +770,7 @@ loadModelParameters <- function(ModelParamFile = "model_parameters.json") {
 #' identify the 'ModuleName', the 'PackageName', and the 'RunFor' value.
 #' @export
 parseModelScript <-
-  function(FilePath = "run_model.R",
+  function(FilePath = "Run_Model.R",
            TestMode = FALSE) {
     if (!TestMode) {
       writeLog("Parsing model script")

--- a/sources/framework/visioneval/R/visioneval.R
+++ b/sources/framework/visioneval/R/visioneval.R
@@ -56,13 +56,15 @@
 #' @export
 initializeModel <-
   function(
+    ModelScriptFile = "Run_Model.R",
     ParamDir = "defs",
     RunParamFile = "run_parameters.json",
     GeoFile = "geo.csv",
     ModelParamFile = "model_parameters.json",
     LoadDatastore = FALSE,
     DatastoreName = NULL,
-    SaveDatastore = TRUE) {
+    SaveDatastore = TRUE
+  ) {
 
     #Initialize model state and log files
     #------------------------------------
@@ -218,7 +220,7 @@ initializeModel <-
     #Parse script to make table of all the module calls, check and combine specs
     #---------------------------------------------------------------------------
     #Parse script and make data frame of modules that are called directly
-    parseModelScript(FilePath = "run_model.R")
+    parseModelScript(ModelScriptFile)
     ModuleCalls_df <- unique(getModelState()$ModuleCalls_df)
     #Get list of installed packages
     InstalledPkgs_ <- rownames(installed.packages())

--- a/sources/models/VERPAT/Run_Model.R
+++ b/sources/models/VERPAT/Run_Model.R
@@ -11,7 +11,7 @@ library(visioneval)
 #Initialize model
 #----------------
 initializeModel(
-  ModelScriptFile = "Run_Model.R",
+  ModelScriptFile = "../Run_Model.R",
   ParamDir = "defs",
   RunParamFile = "run_parameters.json",
   GeoFile = "geo.csv",

--- a/sources/models/VERPAT/run_model.R
+++ b/sources/models/VERPAT/run_model.R
@@ -11,6 +11,7 @@ library(visioneval)
 #Initialize model
 #----------------
 initializeModel(
+  ModelScriptFile = "Run_Model.R",
   ParamDir = "defs",
   RunParamFile = "run_parameters.json",
   GeoFile = "geo.csv",

--- a/sources/models/VERSPM/Run_Model.R
+++ b/sources/models/VERSPM/Run_Model.R
@@ -1,0 +1,65 @@
+#===========
+#run_model.R
+#===========
+
+#This script demonstrates the VisionEval framework for the RSPM model.
+
+#Load libraries
+#--------------
+library(visioneval)
+
+#Initialize model
+#----------------
+initializeModel(
+  ModelScriptFile = "../Run_Model.R",
+  ParamDir = "defs",
+  RunParamFile = "run_parameters.json",
+  GeoFile = "geo.csv",
+  ModelParamFile = "model_parameters.json",
+  LoadDatastore = FALSE,
+  DatastoreName = NULL,
+  SaveDatastore = TRUE
+  )  
+
+#Run all demo module for all years
+#---------------------------------
+for(Year in getYears()) {
+  runModule("CreateHouseholds",                "VESimHouseholds",       RunFor = "AllYears",    RunYear = Year)
+  runModule("PredictWorkers",                  "VESimHouseholds",       RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignLifeCycle",                 "VESimHouseholds",       RunFor = "AllYears",    RunYear = Year)
+  runModule("PredictIncome",                   "VESimHouseholds",       RunFor = "AllYears",    RunYear = Year)
+  runModule("PredictHousing",                  "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("LocateEmployment",                "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignDevTypes",                  "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("Calculate4DMeasures",             "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateUrbanMixMeasure",        "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignParkingRestrictions",       "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignDemandManagement",          "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignCarSvcAvailability",        "VELandUse",             RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignTransitService",            "VETransportSupply",     RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignRoadMiles",                 "VETransportSupply",     RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignDrivers",                   "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignVehicleOwnership",          "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignVehicleType",               "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("CreateVehicleTable",              "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignVehicleAge",                "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateVehicleOwnCost",         "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("AdjustVehicleOwnership",          "VEHouseholdVehicles",   RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateHouseholdDvmt",          "VEHouseholdTravel",     RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateAltModeTrips",           "VEHouseholdTravel",     RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateVehicleTrips",           "VEHouseholdTravel",     RunFor = "AllYears",    RunYear = Year)
+  runModule("DivertSovTravel",                 "VEHouseholdTravel",     RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculateCarbonIntensity",        "VEPowertrainsAndFuels", RunFor = "AllYears",    RunYear = Year)
+  runModule("AssignHhVehiclePowertrain",       "VEPowertrainsAndFuels", RunFor = "AllYears",    RunYear = Year)
+  for (i in 1:2) {
+    runModule("CalculateBaseRoadDvmt",            "VETravelPerformance",   RunFor = "BaseYear",    RunYear = Year)
+    runModule("CalculateFutureRoadDvmt",          "VETravelPerformance",   RunFor = "NotBaseYear", RunYear = Year)
+    runModule("CalculateRoadPerformance",         "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+    runModule("CalculateMpgMpkwhAdjustments",     "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+    runModule("AdjustHhVehicleMpgMpkwh",          "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+    runModule("CalculateVehicleOperatingCost",    "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+    runModule("BudgetHouseholdDvmt",              "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+  }
+  runModule("CalculateComEnergyAndEmissions",   "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+  runModule("CalculatePtranEnergyAndEmissions", "VETravelPerformance",   RunFor = "AllYears",    RunYear = Year)
+}


### PR DESCRIPTION
For a variety of runtime reasons, I'd like to be able to put the model script in a different folder than the folder that contains "defs" and "inputs" and that holds the outputs.  It's easy to do just by exposing the model script file parameter.  The fix is entirely transparent (due to defaults, no existing model script needs to be changed).  Also, on the defaults, it is very important to use consistent capitalization ("Run_Model.R") and to ensure that the model script file itself is named exactly like that:  otherwise the models crash unpredictably on Linux (and possibly on Mac) due to file system case sensitivity.