### PR TITLE
Changed 'future' processing to use 'sequential'

### DIFF
--- a/sources/VEGUI/FutureTaskProcessor.R
+++ b/sources/VEGUI/FutureTaskProcessor.R
@@ -2,8 +2,11 @@
 # FutureTaskProcessor.R
 # https://gist.github.com/PeterVermont/a4a29d2c6b88e4ee012a869dedb5099c#file-futuretaskprocessor-r
 
+# NOTE: "multiprocess" won't work on many enterprise R installations as it requires opening an internal
+# TCP or UDP port that most firewalls will block.  Use "sequential" instead.
 # The file that 'source's this should also call plan(multiprocess, workers=<desired number of workers>)
 # for example: plan(multiprocess, workers=min((myNumTasks+1), MAX_PROCESSES))
+#   plan(sequential)
 # it is not required to specify workers -- if not then it will default to future::availableCores()
 # use myNumTasks+1 because future uses one process for itself.
 
@@ -261,7 +264,8 @@ fakeDataProcessing <- function(name, duration, sys_sleep = FALSE) {
 
 
 testAsync <- function(loops = future::availableCores() - 1) {
-  plan(multiprocess)
+#  plan(multiprocess)
+  plan(sequential)
   print(paste0("future::availableCores(): ", future::availableCores()))
   loops <- 10 #
   baseWait <- 3

--- a/sources/VEGUI/global.R
+++ b/sources/VEGUI/global.R
@@ -32,7 +32,8 @@ options(DT.options = list(dom = 'tip', rownames = 'f'))
 
 #use of future in shiny
 #http://stackoverflow.com/questions/41610354/calling-a-shiny-javascript-callback-from-within-a-future
-plan(multiprocess) #tell "future" library to use multiprocessing
+# plan(multiprocess) #tell "future" library to use multiprocessing
+plan(sequential) #tell "future" library to use sequential
 
 if (interactive()) {
   options(shiny.reactlog = TRUE)

--- a/sources/modules/VEScenario/R/RunScenarios.R
+++ b/sources/modules/VEScenario/R/RunScenarios.R
@@ -421,8 +421,8 @@ RunScenarios <- function(L){
   ScenarioInProcess_ls <- list()
   NWorkers <- L$Global$Model$NWorkers
   NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
-
+#  plan(multiprocess, workers = NWorkers, gc=TRUE)
+  plan(sequential, workers = NWorkers, gc=TRUE)
   # Update the Scenario Progress Report
   Scenarios_df  <- read.csv(file.path(ModelPath,
                                       L$Global$Model$ScenarioOutputFolder,

--- a/sources/modules/VEScenario/R/VERPATResults.R
+++ b/sources/modules/VEScenario/R/VERPATResults.R
@@ -267,7 +267,8 @@ VERPATResults <- function(L){
   # Set future processors
   NWorkers <- L$Global$Model$NWorkers
   NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
+#  plan(multiprocess, workers = NWorkers, gc=TRUE)
+  plan(sequential, workers = NWorkers, gc=TRUE)
 
   Results_env <- new.env()
   for(sc_path in ScenariosPath_ar){

--- a/sources/modules/VEScenario/R/VERSPMResults.R
+++ b/sources/modules/VEScenario/R/VERSPMResults.R
@@ -378,7 +378,8 @@ VERSPMResults <- function(L){
   # Set future processors
   NWorkers <- L$Global$Model$NWorkers
   NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
+#  plan(multiprocess, workers = NWorkers, gc=TRUE)
+  plan(sequential, workers = NWorkers, gc=TRUE)
 
   Results_env <- new.env()
   for(sc_path in ScenariosPath_ar){


### PR DESCRIPTION
Using plan('multiprocessing') fails to run in environments (e.g. Windows in an enterprise) where users do not have privileges to open ports on the system firewall (even for internal use).

Ideally, we could introduce a configuration parameter that defaults to multiprocess,  but that can be adjusted during installation by attempting to execute a multiprocess plan and trapping the resulting exception to reset the configuration to sequential processing.  I haven't implemented that - this is a hard-coded change.