### PR TITLE
Added a way to specify the type of `plan` for `future` function.

### DIFF
--- a/sources/VEGUI/global.R
+++ b/sources/VEGUI/global.R
@@ -32,7 +32,19 @@ options(DT.options = list(dom = 'tip', rownames = 'f'))
 
 #use of future in shiny
 #http://stackoverflow.com/questions/41610354/calling-a-shiny-javascript-callback-from-within-a-future
-plan(multiprocess) #tell "future" library to use multiprocessing
+# plan(multiprocess) #tell "future" library to use multiprocessing
+
+# Set future processors
+
+planType <- 'multiprocess'  # Will VEGUI work at all with sequential?
+
+if ( exists('planType') && planType == 'multiprocess'){
+  NWorkers <- L$Global$Model$NWorkers
+  NWorkers <- min(max(availableCores()-1, 1), NWorkers)
+  plan(multiprocess, workers = NWorkers, gc=TRUE)
+} else {
+  plan(sequential)
+}
 
 if (interactive()) {
   options(shiny.reactlog = TRUE)

--- a/sources/models/VERSPM/Test1/run_model.R
+++ b/sources/models/VERSPM/Test1/run_model.R
@@ -10,6 +10,8 @@ library(visioneval)
 #devtools::load_all('C:/Users/matt.landis/Git/VisionEval/sources/framework/visioneval/')
 cat('run_model.R: library visioneval loaded\n')
 
+planType <- 'multiprocess'
+
 #Initialize model
 #----------------
 initializeModel(

--- a/sources/models/VERSPM_Scenarios/run_model.R
+++ b/sources/models/VERSPM_Scenarios/run_model.R
@@ -8,6 +8,10 @@
 #--------------
 library(visioneval)
 
+planType <- 'multiprocess'
+
+ptm <- proc.time()
+
 #Initialize model
 #----------------
 initializeModel(
@@ -48,3 +52,5 @@ for(Year in getYears()) {
     RunYear = Year
   )
 }
+
+proc.time() - ptm

--- a/sources/modules/VEScenario/R/BuildScenarios.R
+++ b/sources/modules/VEScenario/R/BuildScenarios.R
@@ -160,6 +160,10 @@ BuildScenarios <- function(L){
   LevelDef_ar <- unique(LevelDef_ar)
 
   # Gather scenario and category config files
+  if (! dir.exists(L$Global$Model$ScenarioOutputFolder) ){
+    dir.create(L$Global$Model$ScenarioOutputFolder)
+  } 
+  
   if(!dir.exists(file.path(RunDir, L$Global$Model$ScenarioOutputFolder))) { 
     if(file.exists(file.path(RunDir, L$Global$Model$ScenarioOutputFolder))){
       file.remove(file.path(RunDir, L$Global$Model$ScenarioOutputFolder))

--- a/sources/modules/VEScenario/R/RunScenarios.R
+++ b/sources/modules/VEScenario/R/RunScenarios.R
@@ -419,10 +419,16 @@ RunScenarios <- function(L){
 
   # A list to store currently running scenarios
   ScenarioInProcess_ls <- list()
-  NWorkers <- L$Global$Model$NWorkers
-  NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
-
+  
+  # Set future processors
+  if ( exists('planType') && planType == 'multiprocess'){
+    NWorkers <- L$Global$Model$NWorkers
+    NWorkers <- min(max(availableCores()-1, 1), NWorkers)
+    plan(multiprocess, workers = NWorkers, gc=TRUE)
+  } else {
+    plan(sequential)
+  }
+  
   # Update the Scenario Progress Report
   Scenarios_df  <- read.csv(file.path(ModelPath,
                                       L$Global$Model$ScenarioOutputFolder,

--- a/sources/modules/VEScenario/R/VERPATResults.R
+++ b/sources/modules/VEScenario/R/VERPATResults.R
@@ -265,10 +265,14 @@ VERPATResults <- function(L){
   InputLabels_ar <- L$Global$Model$InputLabels
 
   # Set future processors
-  NWorkers <- L$Global$Model$NWorkers
-  NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
-
+  if ( exists('planType') && planType == 'multiprocess'){
+    NWorkers <- L$Global$Model$NWorkers
+    NWorkers <- min(max(availableCores()-1, 1), NWorkers)
+    plan(multiprocess, workers = NWorkers, gc=TRUE)
+  } else {
+    plan(sequential)
+  }
+  
   Results_env <- new.env()
   for(sc_path in ScenariosPath_ar){
     Results_env[[basename(sc_path)]] <- data.table(Scenario=basename(sc_path),

--- a/sources/modules/VEScenario/R/VERSPMResults.R
+++ b/sources/modules/VEScenario/R/VERSPMResults.R
@@ -376,10 +376,14 @@ VERSPMResults <- function(L){
   InputLabels_ar <- L$Global$Model$InputLabels
 
   # Set future processors
-  NWorkers <- L$Global$Model$NWorkers
-  NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
-
+  if ( exists('planType') && planType == 'multiprocess'){
+    NWorkers <- L$Global$Model$NWorkers
+    NWorkers <- min(max(availableCores()-1, 1), NWorkers)
+    plan(multiprocess, workers = NWorkers, gc=TRUE)
+  } else {
+    plan(sequential)
+  }
+  
   Results_env <- new.env()
   for(sc_path in ScenariosPath_ar){
     Results_env[[basename(sc_path)]] <- data.table(Scenario=basename(sc_path),


### PR DESCRIPTION
Added a way to specify whether to use `multiprocess` or `sequential` for `future::plan`.  Defaults to `sequential` if it is unspecified.    