### PR TITLE
Improved .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,87 +1,90 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
 language: r
-r: 3.4
-sudo: true
-dist: trusty
-cache: packages
+r: 3.5.1
+dist: xenial
+cache:
+    - packages
+    - directories:
+        - $TRAVIS_BUILD_DIR/ve-lib
+
+# We don't need much of the history
 git:
-  depth: 10
+  depth: 1
   
-# Be strict when checking our package
+# Be less strict when checking our package
 warnings_are_errors: false
 
-# nloptr R package requires libnlopt-dev to be installed, which requires trusty ubuntu
-# phantomjs required for shinytest for VEGUI testing
-before_install:
-  - sudo apt-get update
-  - sudo apt-get -y install libnlopt-dev
-  - "export PHANTOMJS_VERSION=2.1.1"
-  - "phantomjs --version"
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
-  - "hash -r"
-  - "phantomjs --version"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then hash -r; fi"
-  - "phantomjs --version"
+# Need some additional libraries under ubuntu
+addons:
+  apt:
+    packages:
+    - libudunits2-dev
+    - libgdal-dev
 
+# Set up the pair of cache areas
 install:
-  - Rscript -e 'install.packages(c("curl","devtools", "roxygen2", "stringr", "knitr", "data.table", "ordinal", "geosphere", "fields", "car", "pbkrtest", "quantreg", "reshape"))'
-  - Rscript -e 'devtools::install_bioc(c("3.6/BiocInstaller", "3.6/rhdf5"))'
-  # Packages required for VEGUI  
-  - Rscript -e 'install.packages(c("shiny", "shinyjs", "shinyFiles", "DT", "shinyBS", "future", "testit", "jsonlite", "shinyAce", "envDocument", "rhandsontable", "shinyTree",
-                                   "shinytest", "webdriver"))'
-  - Rscript -e 'devtools::install_github(c("tdhock/namedCapture"))'
+  - mkdir -p $TRAVIS_BUILD_DIR/ve-lib
+  - Rscript build/install-deps.R
 
-# setup a different environment variable for each Travis build environment (in the matrix) to run in parallel
+# https://docs.travis-ci.com/user/build-stages#warming-up-a-cache-with-expensive-dependencies
+
+# Dependence Information from original .travis.yml
+
+#    - Folder=Sources/Framework/Visioneval            Depends=
+#    - Folder=Sources/Modules/Ve2001Nhts              Depends=
+#    - Folder=Sources/Modules/Vehouseholdtravel       Depends=Ve2001Nhts
+#    - Folder=Sources/Modules/Vehouseholdvehicles     Depends=Ve2001Nhts,Vehouseholdtravel
+#    - Folder=Sources/Modules/Velanduse               Depends=Ve2001Nhts,Vesimhouseholds
+#    - Folder=Sources/Modules/Vesimhouseholds         Depends=
+#    - Folder=Sources/Modules/Vesyntheticfirms        Depends=
+#    - Folder=Sources/Modules/Vetransportsupply       Depends=
+#    - Folder=Sources/Modules/Vetransportsupplyuse    Depends=
+#    - Folder=Sources/Modules/Vetravelperformance     Depends=Ve2001Nhts,Vehouseholdtravel,Vepowertrainsandfuels
+#    - Folder=Sources/Modules/Vepowertrainsandfuels   Depends=Ve2001Nhts,Vehouseholdtravel
+#    - Folder=Sources/Modules/Vereports               Depends=Ve2001Nhts,Vehouseholdtravel
+#    # - Folder=Sources/Modules/Vescenario            Depends=
+#    - Folder=Sources/Models/Baseyearverpat           Depends=Ve2001Nhts,Vesimhouseholds,Vesyntheticfirms,Velanduse,Vetransportsupply,Vehouseholdtravel,Vehouseholdvehicles,Vetransportsupplyuse,Vereports
+#    - Folder=Sources/Models/Verpat                   Depends=Ve2001Nhts,Vesimhouseholds,Vesyntheticfirms,Velanduse,Vetransportsupply,Vehouseholdtravel,Vehouseholdvehicles,Vetransportsupplyuse,Vereports
+#    - Folder=Sources/Models/Verspm/Test1             Depends=Ve2001Nhts,Vesimhouseholds,Velanduse,Vetransportsupply,Vehouseholdtravel,Vehouseholdvehicles,Vepowertrainsandfuels,Vetravelperformance
+#    - Folder=Sources/Vegui                           Depends=Ve2001Nhts,Vesimhouseholds,Vesyntheticfirms,Velanduse,Vetransportsupply,Vehouseholdtravel,Vehouseholdvehicles,Vetransportsupplyuse,Vereports
+
+# Master library location for built VE modules so they don't confuse the package cache
 env:
-   - FOLDER=sources/framework/visioneval            SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VE2001NHTS              SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VEHouseholdTravel       SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS
-   - FOLDER=sources/modules/VEHouseholdVehicles     SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS,VEHouseholdTravel
-   - FOLDER=sources/modules/VELandUse               SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS,VESimHouseholds
-   - FOLDER=sources/modules/VESimHouseholds         SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VESyntheticFirms        SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VETransportSupply       SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VETransportSupplyUse    SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/modules/VETravelPerformance     SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS,VEHouseholdTravel,VEPowertrainsAndFuels
-   - FOLDER=sources/modules/VEPowertrainsAndFuels   SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS,VEHouseholdTravel
-   - FOLDER=sources/modules/VEReports               SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=VE2001NHTS,VEHouseholdTravel
-   # - FOLDER=sources/modules/VEScenario              SCRIPT=tests/scripts/test.R    TYPE=module      DEPENDS=
-   - FOLDER=sources/models/BaseYearVERPAT           SCRIPT=run_model.R             TYPE=model       DEPENDS=VE2001NHTS,VESimHouseholds,VESyntheticFirms,VELandUse,VETransportSupply,VEHouseholdTravel,VEHouseholdVehicles,VETransportSupplyUse,VEReports
-   - FOLDER=sources/models/VERPAT                   SCRIPT=run_model.R             TYPE=model       DEPENDS=VE2001NHTS,VESimHouseholds,VESyntheticFirms,VELandUse,VETransportSupply,VEHouseholdTravel,VEHouseholdVehicles,VETransportSupplyUse,VEReports
-   - FOLDER=sources/models/VERSPM/Test1             SCRIPT=run_model.R             TYPE=model       DEPENDS=VE2001NHTS,VESimHouseholds,VELandUse,VETransportSupply,VEHouseholdTravel,VEHouseholdVehicles,VEPowertrainsAndFuels,VETravelPerformance
-   - FOLDER=sources/VEGUI                           SCRIPT=run_vegui_test.R        TYPE=model       DEPENDS=VE2001NHTS,VESimHouseholds,VESyntheticFirms,VELandUse,VETransportSupply,VEHouseholdTravel,VEHouseholdVehicles,VETransportSupplyUse,VEReports
+    global: VE_LIBRARY=$TRAVIS_BUILD_DIR/ve-lib
 
-# install and test framework, modules, models, GUI
-script:
-  - |
-    #install framework
-    cd sources/framework/visioneval
-    Rscript -e 'devtools::install_deps(".")'
-    R CMD INSTALL .
-    cd ../../..
-    
-    #install dependent packages
-    IFS=',' read -r -a packages <<< $DEPENDS
-    for element in ${packages[@]}
-    do
-      if ( [ $element != "." ] ); then
-        cd sources/modules/$element
-        Rscript -e 'devtools::install_deps(".")'
-        Rscript -e 'devtools::document()'
-        R CMD INSTALL .
-        cd ../../..
-      fi
-    done
-    
-    # run module or model tests, comment out to finish Travis tests in < 50 min to rebuild caches and then uncomment and rerun
-  - |
-    cd $FOLDER
-    if ( [ $TYPE == "module" ] ); then  Rscript -e 'devtools::install_deps(".")'; fi  
-  - if ( [ $TYPE == "module" ] ); then  Rscript -e 'devtools::check(".")'; fi
-  - if ( [ $TYPE == "module" ] ); then  Rscript -e "tryCatch( source( '$SCRIPT' ) )"; fi
-  - if ( [ $TYPE == "module" ] ); then  R CMD INSTALL .; fi
-  - if ( [ $TYPE == "model" ] ); then  Rscript -e "tryCatch( source( '$SCRIPT' ) )"; fi
+# Set up job stage processing to incrementally build and test VE
+# packages.  No individual job runs for over 30 minutes, total run time
+# 1:40 to 2:10 (the latter if R package cached needs to be built).
+
+jobs:
+    include:
+        - stage: Build cache
+          script: true
+        - stage: VisionEval
+          script: bash build/make-module.sh sources/framework/visioneval
+        - stage: Group 1 Modules
+          script:
+            - bash build/make-module.sh sources/modules/VE2001NHTS
+            - bash build/make-module.sh sources/modules/VESimHouseholds
+            - bash build/make-module.sh sources/modules/VESyntheticFirms
+            - bash build/make-module.sh sources/modules/VETransportSupply
+            - bash build/make-module.sh sources/modules/VETransportSupplyUse
+        - stage: Group 2 Modules
+          script:
+            - bash build/make-module.sh sources/modules/VEHouseholdTravel
+            - bash build/make-module.sh sources/modules/VELandUse
+            - bash build/make-module.sh sources/modules/VEPowertrainsAndFuels
+        - stage: Group 3 Modules
+          script:
+            - bash build/make-module.sh sources/modules/VEHouseholdVehicles
+            - bash build/make-module.sh sources/modules/VETravelPerformance
+            - bash build/make-module.sh sources/modules/VEReports
+        - stage: Group 4 Modules
+          script:
+            - bash build/make-module.sh sources/modules/VETravelPerformance
+        - stage: Models and VEGUI (parallel)
+          script: bash build/run-model.sh sources/models/BaseYearVERPAT/run_model.R
+        - script: bash build/run-model.sh sources/models/VERPAT/run_model.R
+        - script: bash build/run-model.sh sources/models/VERSPM/Test1/run_model.R
+        - script: bash build/run-model.sh sources/VEGUI/run_vegui_test.R
+        - stage: Cleanup
+          script: rm -rf $VE_LIBRARY/*

--- a/build/install-deps.R
+++ b/build/install-deps.R
@@ -1,0 +1,52 @@
+devtools.CRAN <- c(
+   "devtools"
+  ,"knitr"
+  ,"roxygen2"
+  ,"curl"
+  ,"yaml"
+)
+modules.BioC <- c("rhdf5")
+vegui.github <- c("tdhock/namedCapture")
+modules.CRAN <- c(
+   "jsonlite"
+  ,"stringr"
+  ,"filesstrings"
+  ,"knitr"
+  ,"usethis"
+  ,"reshape"
+  ,"car"
+  ,"pbkrtest"
+  ,"quantreg"
+  ,"geosphere"
+  ,"fields"
+  ,"tidycensus"
+  ,"plot3D"
+  ,"pscl"
+  ,"ordinal"
+  ,"reshape2"
+  ,"data.table"
+  ,"future.callr"
+)
+vegui.CRAN <- c(
+   "DT"
+  ,"envDocument"
+  ,"rhandsontable"
+  ,"shiny"
+  ,"shinyBS"
+  ,"shinyFiles"
+  ,"shinyjs"
+  ,"shinytest"
+  ,"testit"
+  ,"testthat"
+  ,"webdriver"
+)
+
+cat("Installing to:",.libPaths()[1],"\n")
+
+# Acknowledge the cache for the top-level packages
+sought.pkgs <- c(devtools.CRAN,modules.CRAN,vegui.CRAN)
+new.pkgs <- sought.pkgs[ ! (sought.pkgs %in% installed.packages()[,"Package"]) ]
+if( length(new.pkgs) > 0 ) install.packages(new.pkgs)
+
+devtools::install_bioc(c("3.6/BiocInstaller", paste("3.6",modules.BioC,sep="/")))
+devtools::install_github(vegui.github)

--- a/build/make-module.sh
+++ b/build/make-module.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ev
+
+BUILD_LIB=${VE_LIBRARY:-$TRAVIS_BUILD_DIR/ve-lib}
+[ -d ${BUILD_LIB} ] || mkdir -p ${BUILD_LIB}
+
+if [ -n "${BUILD_LIB}" ]
+then
+  export R_LIBS_USER=${BUILD_LIB}:${R_LIBS_USER}
+fi
+
+echo Operating in $(pwd)
+pushd $1
+TEST_SCRIPT=${2:-${VE_SCRIPT:-tests/scripts/test.R}}
+echo TEST_SCRIPT=${TEST_SCRIPT}
+Rscript -e "devtools::check('.')"
+echo Executing ${TEST_SCRIPT} in $(pwd)
+Rscript -e "tryCatch( source('${TEST_SCRIPT}') )"
+echo Installing to ${BUILD_LIB}
+R CMD INSTALL -l "${BUILD_LIB}" . # Save the installed package for later use
+popd

--- a/build/run-model.sh
+++ b/build/run-model.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+set -ev
+
+BUILD_LIB=${VE_LIBRARY:-$TRAVIS_BUILD_DIR/ve-lib}
+[ -d ${BUILD_LIB} ] || mkdir -p ${BUILD_LIB}
+
+if [ -n "${BUILD_LIB}" ]
+then
+  export R_LIBS_USER=${BUILD_LIB}:${R_LIBS_USER}
+fi
+
+MODEL_DIR=$(dirname $1)
+MODEL_DIR=${MODEL_DIR:-.}
+
+pushd ${MODEL_DIR}
+Rscript -e "tryCatch( source('$(basename $1)') )"
+popd


### PR DESCRIPTION
Changes .travis.yml to use Travis "stages" and "cache" to isolate time-consuming tasks in a sequence of dependent jobs (notably building the R package cache), and to avoid building the VE packages more than once in the overall build.  Implements identical functionality to the existing .travis.yml, but runs in roughly 1/3 the time without ever timing out (so no more bogus check-ins to force a cache rebuild).

See https://github.com/VisionEval/VisionEval-dev, where this change originated for ongoing updates.